### PR TITLE
Updating check for isolated junctions and links

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,8 @@ matrix:
       env: CONDA_ENV=py34
     - python: 3.5
       env: CONDA_ENV=py35
+    - python: 3.6
+      env: CONDA_ENV=py36
 
 addons:
     apt:

--- a/ci/requirements-py27-min.yml
+++ b/ci/requirements-py27-min.yml
@@ -11,7 +11,7 @@ dependencies:
     - plotly
     - pyqt==4.11.4
     - nose==1.3.7
-    - sympy==1.0
+    - sympy==1.1
     - xlwt==1.1.1
     - enum34==1.1.2
     - pip:

--- a/ci/requirements-py34.yml
+++ b/ci/requirements-py34.yml
@@ -10,7 +10,7 @@ dependencies:
     - matplotlib
     - plotly
     - nose
-    - sympy
+    - sympy=1.1
     - xlwt
     - pip:
         - coveralls

--- a/ci/requirements-py35.yml
+++ b/ci/requirements-py35.yml
@@ -10,7 +10,7 @@ dependencies:
     - matplotlib
     - plotly
     - nose
-    - sympy
+    - sympy=1.1
     - xlwt
     - pip:
         - coveralls

--- a/ci/requirements-py36.yml
+++ b/ci/requirements-py36.yml
@@ -2,7 +2,7 @@ name: test_env
 channels:
     - defaults
 dependencies:
-    - python=2.7 
+    - python=3.6
     - numpy
     - scipy
     - networkx
@@ -12,6 +12,5 @@ dependencies:
     - nose
     - sympy=1.1
     - xlwt
-    - enum34
     - pip:
         - coveralls

--- a/examples/converting_units.py
+++ b/examples/converting_units.py
@@ -1,17 +1,18 @@
 from sympy.physics import units
 
 # Convert 12 inches to meters
-D = 12*float(units.inch/units.meter)
+D = units.convert_to(12*units.inch, units.meter)
 
-# Covert 0.2 mg/L to kg/m3
-C = 0.2*float((units.mg/units.l)/(units.kg/units.m**3))
+# Convert 0.2 mg/L to kg/m3
+C = units.convert_to(0.2*units.mg/units.l, units.kg/units.m**3)
 
 # Convert 30 psi to m (assuming density = 1000 kg/m3 and gravity = 9.81 m/s2)
-if not units.find_unit('waterpressure'):
-    units.waterpressure = 9810*units.Pa
-P = 30*float(units.psi/units.waterpressure)
+P = 30 * units.psi
+P = units.convert_to(P, units.Pa)  # convert psi to pascal
+waterpressure = 9810 * units.Pa/units.m
+H = P/waterpressure  # convert pascal to m
 
 # Convert 200 gallons/day to m3/day 
-if not units.find_unit('gallon'):
+if not 'gallon' in units.find_unit('volume'):
     units.gallon = 4*units.quart
-R = 200*float(units.gallon/units.m**3) 
+R = units.convert_to(200*units.gallon/units.day, units.m**3/units.day)

--- a/wntr/sim/core.py
+++ b/wntr/sim/core.py
@@ -10,6 +10,7 @@ import time
 import sys
 import logging
 import scipy.sparse
+import scipy.sparse.csr
 
 logger = logging.getLogger(__name__)
 
@@ -508,11 +509,26 @@ class WNTRSimulator(WaterNetworkSimulator):
                 vals.append(1)
 
         self._internal_graph = scipy.sparse.csr_matrix((vals, (rows, cols)))
+        ndx_map = {}
+        for link_name, link in self._wn.links():
+            ndx1 = None
+            ndx2 = None
+            from_node_name = link.start_node
+            to_node_name = link.end_node
+            from_node_id = self._model._node_name_to_id[from_node_name]
+            to_node_id = self._model._node_name_to_id[to_node_name]
+            ndx1 = _get_csr_data_index(self._internal_graph, from_node_id, to_node_id)
+            ndx2 = _get_csr_data_index(self._internal_graph, to_node_id, from_node_id)
+            ndx_map[link] = (ndx1, ndx2)
+        self._map_link_to_internal_graph_data_ndx = ndx_map
 
         self._node_pairs_with_multiple_links = {}
         for from_node_id, to_node_id in n_links.keys():
             if n_links[(from_node_id, to_node_id)] > 1:
+                if (to_node_id, from_node_id) in self._node_pairs_with_multiple_links:
+                    continue
                 self._internal_graph[from_node_id, to_node_id] = 0
+                self._internal_graph[to_node_id, from_node_id] = 0
                 from_node_name = self._model._node_id_to_name[from_node_id]
                 to_node_name = self._model._node_id_to_name[to_node_id]
                 tmp_list = self._node_pairs_with_multiple_links[(from_node_id, to_node_id)] = []
@@ -522,129 +538,113 @@ class WNTRSimulator(WaterNetworkSimulator):
                         tmp_list.append(link)
                         if isinstance(link, wntr.network.Pipe):
                             if link.status != wntr.network.LinkStatus.closed:
-                                self._internal_graph[from_node_id, to_node_id] = 1
+                                ndx1, ndx2 = ndx_map[link]
+                                self._internal_graph.data[ndx1] = 1
+                                self._internal_graph.data[ndx2] = 1
                         elif isinstance(link, wntr.network.Pump):
                             if link.status != wntr.network.LinkStatus.closed and link._cv_status != wntr.network.LinkStatus.closed:
-                                self._internal_graph[from_node_id, to_node_id] = 1
+                                ndx1, ndx2 = ndx_map[link]
+                                self._internal_graph.data[ndx1] = 1
+                                self._internal_graph.data[ndx2] = 1
                         elif isinstance(link, wntr.network.Valve):
                             if link.status != wntr.network.LinkStatus.closed and link._status != wntr.network.LinkStatus.closed:
-                                self._internal_graph[from_node_id, to_node_id] = 1
+                                ndx1, ndx2 = ndx_map[link]
+                                self._internal_graph.data[ndx1] = 1
+                                self._internal_graph.data[ndx2] = 1
                         else:
                             raise RuntimeError('Unrecognized link type.')
 
     def _update_internal_graph(self):
+        data = self._internal_graph.data
+        ndx_map = self._map_link_to_internal_graph_data_ndx
         for obj_name, obj in self._control_log.changed_objects.items():
             changed_attrs = self._control_log.changed_attributes[obj_name]
             if type(obj) == wntr.network.Pipe:
                 if 'status' in changed_attrs:
                     if obj.status == wntr.network.LinkStatus.opened:
-                        start_node_name = obj.start_node
-                        end_node_name = obj.end_node
-                        start_node_id = self._model._node_name_to_id[start_node_name]
-                        end_node_id = self._model._node_name_to_id[end_node_name]
-                        self._internal_graph[start_node_id, end_node_id] = 1
-                        self._internal_graph[end_node_id, start_node_id] = 1
+                        ndx1, ndx2 = ndx_map[obj]
+                        data[ndx1] = 1
+                        data[ndx2] = 1
                     elif obj.status == wntr.network.LinkStatus.closed:
-                        start_node_name = obj.start_node
-                        end_node_name = obj.end_node
-                        start_node_id = self._model._node_name_to_id[start_node_name]
-                        end_node_id = self._model._node_name_to_id[end_node_name]
-                        self._internal_graph[start_node_id, end_node_id] = 0
-                        self._internal_graph[end_node_id, start_node_id] = 0
+                        ndx1, ndx2 = ndx_map[obj]
+                        data[ndx1] = 0
+                        data[ndx2] = 0
                     else:
                         raise RuntimeError('Pipe status not recognized: %s', getattr(obj, 'status'))
             elif type(obj) == wntr.network.Pump:
                 if 'status' in changed_attrs and '_cv_status' in changed_attrs:
                     if obj.status == wntr.network.LinkStatus.closed and obj._cv_status == wntr.network.LinkStatus.closed:
-                        start_node_name = obj.start_node
-                        end_node_name = obj.end_node
-                        start_node_id = self._model._node_name_to_id[start_node_name]
-                        end_node_id = self._model._node_name_to_id[end_node_name]
-                        self._internal_graph[start_node_id, end_node_id] = 0
-                        self._internal_graph[end_node_id, start_node_id] = 0
+                        ndx1, ndx2 = ndx_map[obj]
+                        data[ndx1] = 0
+                        data[ndx2] = 0
                     elif obj.status == wntr.network.LinkStatus.opened and obj._cv_status == wntr.network.LinkStatus.opened:
-                        start_node_name = obj.start_node
-                        end_node_name = obj.end_node
-                        start_node_id = self._model._node_name_to_id[start_node_name]
-                        end_node_id = self._model._node_name_to_id[end_node_name]
-                        self._internal_graph[start_node_id, end_node_id] = 1
-                        self._internal_graph[end_node_id, start_node_id] = 1
+                        ndx1, ndx2 = ndx_map[obj]
+                        data[ndx1] = 1
+                        data[ndx2] = 1
                     else:
                         pass
                 elif 'status' in changed_attrs:
                     if obj.status == wntr.network.LinkStatus.closed:
                         if obj._cv_status == wntr.network.LinkStatus.opened:
-                            start_node_name = obj.start_node
-                            end_node_name = obj.end_node
-                            start_node_id = self._model._node_name_to_id[start_node_name]
-                            end_node_id = self._model._node_name_to_id[end_node_name]
-                            self._internal_graph[start_node_id, end_node_id] = 0
-                            self._internal_graph[end_node_id, start_node_id] = 0
+                            ndx1, ndx2 = ndx_map[obj]
+                            data[ndx1] = 0
+                            data[ndx2] = 0
                     elif obj.status == wntr.network.LinkStatus.opened:
                         if obj._cv_status == wntr.network.LinkStatus.opened:
-                            start_node_name = obj.start_node
-                            end_node_name = obj.end_node
-                            start_node_id = self._model._node_name_to_id[start_node_name]
-                            end_node_id = self._model._node_name_to_id[end_node_name]
-                            self._internal_graph[start_node_id, end_node_id] = 1
-                            self._internal_graph[end_node_id, start_node_id] = 1
+                            ndx1, ndx2 = ndx_map[obj]
+                            data[ndx1] = 1
+                            data[ndx2] = 1
                 elif '_cv_status' in changed_attrs:
                     if obj._cv_status == wntr.network.LinkStatus.closed:
                         if obj.status == wntr.network.LinkStatus.opened:
-                            start_node_name = obj.start_node
-                            end_node_name = obj.end_node
-                            start_node_id = self._model._node_name_to_id[start_node_name]
-                            end_node_id = self._model._node_name_to_id[end_node_name]
-                            self._internal_graph[start_node_id, end_node_id] = 0
-                            self._internal_graph[end_node_id, start_node_id] = 0
+                            ndx1, ndx2 = ndx_map[obj]
+                            data[ndx1] = 0
+                            data[ndx2] = 0
                     elif obj._cv_status == wntr.network.LinkStatus.opened:
                         if obj.status == wntr.network.LinkStatus.opened:
-                            start_node_name = obj.start_node
-                            end_node_name = obj.end_node
-                            start_node_id = self._model._node_name_to_id[start_node_name]
-                            end_node_id = self._model._node_name_to_id[end_node_name]
-                            self._internal_graph[start_node_id, end_node_id] = 1
-                            self._internal_graph[end_node_id, start_node_id] = 1
+                            ndx1, ndx2 = ndx_map[obj]
+                            data[ndx1] = 1
+                            data[ndx2] = 1
             elif type(obj) == wntr.network.Valve:
                 if ((obj.status == wntr.network.LinkStatus.opened or
                              obj.status == wntr.network.LinkStatus.active) and
                         (obj._status == wntr.network.LinkStatus.opened or
                                  obj._status == wntr.network.LinkStatus.active)):
-                    start_node_name = obj.start_node
-                    end_node_name = obj.end_node
-                    start_node_id = self._model._node_name_to_id[start_node_name]
-                    end_node_id = self._model._node_name_to_id[end_node_name]
-                    self._internal_graph[start_node_id, end_node_id] = 1
-                    self._internal_graph[end_node_id, start_node_id] = 1
+                    ndx1, ndx2 = ndx_map[obj]
+                    data[ndx1] = 1
+                    data[ndx2] = 1
                 elif obj.status == wntr.network.LinkStatus.closed:
-                    start_node_name = obj.start_node
-                    end_node_name = obj.end_node
-                    start_node_id = self._model._node_name_to_id[start_node_name]
-                    end_node_id = self._model._node_name_to_id[end_node_name]
-                    self._internal_graph[start_node_id, end_node_id] = 0
-                    self._internal_graph[end_node_id, start_node_id] = 0
+                    ndx1, ndx2 = ndx_map[obj]
+                    data[ndx1] = 0
+                    data[ndx2] = 0
                 elif obj.status == wntr.network.LinkStatus.active and obj._status == wntr.network.LinkStatus.closed:
-                    start_node_name = obj.start_node
-                    end_node_name = obj.end_node
-                    start_node_id = self._model._node_name_to_id[start_node_name]
-                    end_node_id = self._model._node_name_to_id[end_node_name]
-                    self._internal_graph[start_node_id, end_node_id] = 0
-                    self._internal_graph[end_node_id, start_node_id] = 0
+                    ndx1, ndx2 = ndx_map[obj]
+                    data[ndx1] = 0
+                    data[ndx2] = 0
 
         for key, link_list in self._node_pairs_with_multiple_links.items():
             from_node_id = key[0]
             to_node_id = key[1]
-            self._internal_graph[from_node_id, to_node_id] = 0
+            first_link = link_list[0]
+            ndx1, ndx2 = ndx_map[first_link]
+            data[ndx1] = 0
+            data[ndx2] = 0
             for link in link_list:
                 if isinstance(link, wntr.network.Pipe):
                     if link.status != wntr.network.LinkStatus.closed:
-                        self._internal_graph[from_node_id, to_node_id] = 1
+                        ndx1, ndx2 = ndx_map[link]
+                        data[ndx1] = 1
+                        data[ndx2] = 1
                 elif isinstance(link, wntr.network.Pump):
                     if link.status != wntr.network.LinkStatus.closed and link._cv_status != wntr.network.LinkStatus.closed:
-                        self._internal_graph[from_node_id, to_node_id] = 1
+                        ndx1, ndx2 = ndx_map[link]
+                        data[ndx1] = 1
+                        data[ndx2] = 1
                 elif isinstance(link, wntr.network.Valve):
                     if link.status != wntr.network.LinkStatus.closed and link._status != wntr.network.LinkStatus.closed:
-                        self._internal_graph[from_node_id, to_node_id] = 1
+                        ndx1, ndx2 = ndx_map[link]
+                        data[ndx1] = 1
+                        data[ndx2] = 1
                 else:
                     raise RuntimeError('Unrecognized link type.')
 
@@ -714,3 +714,20 @@ class WNTRSimulator(WaterNetworkSimulator):
 
         return isolated_junctions, isolated_links
 
+
+def _get_csr_data_index(a, row, col):
+    """
+    Parameters:
+    a: scipy.sparse.csr.csr_matrix
+    row: int
+    col: int
+    """
+    row_indptr = a.indptr[row]
+    num = a.indptr[row+1] - row_indptr
+    cols = a.indices[row_indptr:row_indptr+num]
+    n = 0
+    for j in cols:
+        if j == col:
+            return row_indptr + n
+        n += 1
+    raise RuntimeError('Unable to find csr data index.')

--- a/wntr/sim/core.py
+++ b/wntr/sim/core.py
@@ -671,10 +671,10 @@ class WNTRSimulator(WaterNetworkSimulator):
         #             isolated_links.add(key)
         # return isolated_junctions, isolated_links
 
-        node_set = set(range(self._model.num_nodes))
+        node_set = [1 for i in range(self._model.num_nodes)]
 
         def grab_group(node_id):
-            node_set.remove(node_id)
+            node_set[node_id] = 0
             nodes_to_explore = set()
             nodes_to_explore.add(node_id)
             indptr = self._internal_graph.indptr
@@ -691,25 +691,25 @@ class WNTRSimulator(WaterNetworkSimulator):
                 for i, val in enumerate(vals):
                     if val == 1:
                         col = cols[i]
-                        if col in node_set:
-                            node_set.remove(col)
+                        if node_set[col] ==1:
+                            node_set[col] = 0
                             nodes_to_explore.add(col)
 
         for tank_name, tank in self._wn.nodes(wntr.network.Tank):
             tank_id = self._model._node_name_to_id[tank_name]
-            if tank_id in node_set:
+            if node_set[tank_id] == 1:
                 grab_group(tank_id)
             else:
                 continue
 
         for reservoir_name, reservoir in self._wn.nodes(wntr.network.Reservoir):
             reservoir_id = self._model._node_name_to_id[reservoir_name]
-            if reservoir_id in node_set:
+            if node_set[reservoir_id] == 1:
                 grab_group(reservoir_id)
             else:
                 continue
 
-        isolated_junction_ids = list(node_set)
+        isolated_junction_ids = [i for i in range(len(node_set)) if node_set[i] == 1]
         isolated_junctions = set()
         isolated_links = set()
         for j_id in isolated_junction_ids:


### PR DESCRIPTION
The check for isolated junctions and links no longer uses a deep copy of the networkx graph or nor uses recursion. The reason for this is to fix strange python crashes on specific operating systems.