### PR TITLE
fire flow method and example

### DIFF
--- a/examples/fire_flow.py
+++ b/examples/fire_flow.py
@@ -1,0 +1,36 @@
+"""
+The following example uses WNTR to perform a hydraulic simulation of the 
+network both with and without fire fighting flow demands.
+"""
+import matplotlib.pyplot as plt
+import wntr
+
+plt.close('all')
+
+# Create a water network model both with and without fire fighting demand
+inp_file = 'networks/Net3.inp'
+wn = wntr.network.WaterNetworkModel(inp_file)
+wn_fire = wntr.network.WaterNetworkModel(inp_file)
+
+# Add fire demand
+fire_name = 'fire_pattern'
+fire_flow_demand = 0.252 # 4000 gal/min = 0.252 m3/s
+fire_start = 10*3600
+fire_end = 36*3600
+node = wn_fire.get_node('197')
+node.add_fire_fighting_demand(wn_fire, fire_flow_demand, wn.options.time.pattern_timestep, wn.options.time.duration, 'fire_pattern', fire_start, fire_end)
+
+# Simulate hydraulics with and without fire
+sim = wntr.sim.WNTRSimulator(wn, mode='PDD')
+results = sim.run_sim()
+fire_sim = wntr.sim.WNTRSimulator(wn_fire, mode='PDD')
+fire_results = fire_sim.run_sim()
+
+# Plot resulting differences on the network
+pressure_at_24hr = results.node['pressure'].loc[24*3600, :]
+fire_pressure_at_24hr = fire_results.node['pressure'].loc[24*3600, :]
+pressure_difference = fire_pressure_at_24hr - pressure_at_24hr
+wntr.graphics.plot_network(wn, node_attribute=pressure_difference, node_size=30, 
+                        title='Nominal - Fire Fighting \npressure difference at 24 hours')
+
+

--- a/wntr/network/elements.py
+++ b/wntr/network/elements.py
@@ -195,6 +195,44 @@ class Junction(Node):
         self._leak = False
         wn._discard_control(self._leak_start_control_name)
         wn._discard_control(self._leak_end_control_name)
+        
+    def add_fire_fighting_demand(self, wn, fire_flow_demand, pattern_timestep, sim_duration, pattern_name=None, fire_start=None, fire_end=None):
+        """Add a new fire flow demand entry to the Junction
+        
+        Parameters
+        ----------
+        wn : :class:`~wntr.network.model.WaterNetworkModel`
+           Water network model
+        fire_flow_demand : float
+            The base demand value for this new entry
+        pattern_timestep : str
+            The timestep on which the pattern is
+        sim_duration : int
+            Duration of the simulation in seconds.
+        pattern_name : str or None
+            The name of the pattern to use 
+        fire_start : int
+            Start time of the fire flow in seconds. If fire_start is None, it
+            is assumed that the fire flow starts 4 hours into the simulation.
+        fire_end : int
+            End time of the fire flow in seconds. If fire_end is None, it is 
+            assumed that the fire flow ends at the end of the simulation.
+        """
+        if pattern_name is None:
+            pattern_name = self._name+'_fire'
+        if fire_start is None:
+            fire_start = 4*60*60
+        if fire_end is None:
+            fire_end = sim_duration
+        fire_flow_pattern = Pattern(pattern_name).binary_pattern(pattern_name, 
+                                          step_size=pattern_timestep,
+                                          start_time=fire_start,
+                                          end_time=fire_end,
+                                          duration=sim_duration)
+        wn.add_pattern(pattern_name, fire_flow_pattern)
+        self._pattern_reg.add_usage(pattern_name, (self.name, 'Junction'))
+        self.demand_timeseries_list.append((fire_flow_demand, fire_flow_pattern, 'Fire_Flow'))
+
 
 
 class Tank(Node):


### PR DESCRIPTION
- node.add_fire_fighting_demand method added (creates binary_pattern for fire fighting flow)
- added example showing how to use the method

Note: 
The USEPA/WNTR GitHub site, https://github.com/USEPA/WNTR, does not link to Travis CI for continuous integration software testing.  
The core development team uses the sandialabs/WNTR fork, https://github.com/sandialabs/wntr, to run tests.
To submit a Pull Request to USEPA/WNTR, the developer needs to link their fork to Travis so that test results can be inspected.
If the developer does not have Travis linked to their fork, the Pull Request can be submitted to the sandialabs/WNTR fork.

